### PR TITLE
Add ntfy test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Currently maintained by [zudsniper](https://github.com/zudsniper).
 - **Customizable Messages**: Send personalized notifications with title, body, and links
 - **Discord Embed Support**: Send rich, customizable Discord embed notifications
 - **Discord Webhook Example**: Now includes a sample Discord webhook config (`discord_webhook.json`) and test script (`src/test-discord.js`)
+- **ntfy Webhook Example**: Includes a sample ntfy config (`ntfy-webhook.json`) and test script (`src/test-ntfy.js`)
 - **Improved Discord/NTFY Logic**: Enhanced webhook handling and configuration types
 
 ## Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-notifications",
-  "version": "2.3.1",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-notifications",
-      "version": "2.3.1",
+      "version": "2.5.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.9.0",
         "zod": "^3.22.4"

--- a/src/test-ntfy.js
+++ b/src/test-ntfy.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+/**
+ * Test script for ntfy webhook notifications
+ *
+ * Usage: node src/test-ntfy.js
+ */
+
+const NTFY_URL = process.env.NTFY_WEBHOOK_URL || process.env.WEBHOOK_URL || 'https://ntfy.sh/BKYV4aRVghV6Pag4';
+
+async function sendNtfy(body, headers = {}) {
+  const res = await fetch(NTFY_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'text/plain',
+      ...headers
+    },
+    body
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`Failed (${res.status}): ${text}`);
+  }
+  console.log(`Sent (${res.status}): ${text}`);
+}
+
+async function runTests() {
+  console.log('Starting ntfy webhook tests...');
+  await sendNtfy('Test 1: Basic notification');
+  await sendNtfy('Test 2: High priority', { Priority: '5' });
+  await sendNtfy('Test 3: With link and attachment', {
+    Click: 'https://github.com/zudsniper/mcp-server-notifier',
+    Attach: 'https://ntfy.sh/static/logo.png'
+  });
+  console.log('All ntfy tests completed');
+}
+
+runTests().catch(err => {
+  console.error('Error running ntfy tests:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `src/test-ntfy.js` helper for sending test messages
- document ntfy example in README
- update package-lock.json version

## Testing
- `npm run build`
- `node src/test-ntfy.js` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_688d39c02c208328ad19652282b810e1