### PR TITLE
feat: Add full Slack notification support

### DIFF
--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -161,14 +161,55 @@ Ntfy has the most complete implementation of all features:
 - **Priority**: Native support (1-5)
 - **Attachments**: Multiple attachments supported
 
-### Discord/Slack/Teams/Feishu
+### Discord
+
+Discord notifications are sent as rich embeds, which allows for a high degree of formatting.
+
+- **Templates**: Implemented using custom-formatted embeds.
+- **Priority**: Mapped to embed colors (e.g., red for high priority).
+- **Actions**: Rendered as clickable links within the embed.
+- **Attachments**: Displayed as fields in the embed.
+
+### Slack
+
+Slack notifications are sent using **Block Kit** and **attachments**, which provide a rich and interactive experience.
+
+#### Configuration
+
+To use Slack, set your `WEBHOOK_TYPE` to `slack` and provide an **Incoming Webhook URL**.
+
+1.  Create a new Slack App in your workspace if you don't have one already.
+2.  Navigate to **Incoming Webhooks** and activate it.
+3.  Click **Add New Webhook to Workspace**.
+4.  Choose the channel where you want messages to be posted and click **Authorize**.
+5.  Copy the provided webhook URL (e.g., `https://hooks.slack.com/services/...`). This is your `WEBHOOK_URL`.
+
+**Important**: The channel is determined by the webhook URL itself. If you want to send notifications to different channels, you must create a separate webhook for each one.
+
+#### Feature Implementation
+
+- **Templates**: Implemented using a combination of Block Kit and colored attachments.
+  - `status`: Adds a context block with a status icon and text.
+  - `progress`: Shows a text-based progress bar.
+  - `problem`: Uses a red attachment color and displays error details in a pre-formatted block.
+  - `question`: Lists options in the message body.
+- **Priority**: Mapped to the attachment color on the side of the message.
+  - 5 (High): Red
+  - 4 (Medium): Yellow
+  - 3 (Normal): Blue
+  - 1-2 (Low): Green
+- **Actions**: Rendered as interactive buttons. Note that all actions (`view` and `http`) are treated as simple links, as webhooks do not support custom HTTP requests from buttons.
+- **Attachments**: Appended as links in the message body.
+- **Images**: The `imageUrl` is displayed as a large image block.
+
+### Teams/Feishu
 
 These providers implement templating through custom formatting:
 
-- **Templates**: Formatted as structured messages/embeds
-- **Actions**: Limited support (typically as buttons or links)
-- **Priority**: Represented visually (e.g., colors, icons)
-- **Attachments**: Limited to single images in most cases
+- **Templates**: Formatted as structured messages/cards.
+- **Actions**: Limited support (typically as buttons or links).
+- **Priority**: Represented visually (e.g., colors, icons).
+- **Attachments**: Limited to single images in most cases.
 
 ### Generic/Custom
 

--- a/examples/slack-webhook.json
+++ b/examples/slack-webhook.json
@@ -2,6 +2,11 @@
   "webhook": {
     "type": "slack",
     "url": "https://hooks.slack.com/services/your-slack-webhook-url",
-    "name": "Slack Task Notifier"
+    "name": "MCP Notifier",
+    "username": "MCP Bot",
+    "avatarUrl": "https://raw.githubusercontent.com/sammcj/mcp-icons/main/mcp-icon-128.png"
+  },
+  "imgur": {
+    "clientId": "your-imgur-client-id"
   }
 }

--- a/src/test-slack.js
+++ b/src/test-slack.js
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+
+/**
+ * Test script for Slack webhook notifications
+ *
+ * Usage: node src/test-slack.js
+ *
+ * You need to have a SLACK_WEBHOOK_URL environment variable set.
+ */
+
+import fetch from 'node-fetch';
+
+const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
+
+if (!SLACK_WEBHOOK_URL) {
+  console.error('Error: SLACK_WEBHOOK_URL environment variable not set.');
+  console.error('Please set it to your Slack incoming webhook URL.');
+  process.exit(1);
+}
+
+async function sendSlackMessage(payload) {
+  const response = await fetch(SLACK_WEBHOOK_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Failed to send Slack message: ${response.status} ${text}`);
+  }
+
+  return response;
+}
+
+async function runTests() {
+  console.log('Starting Slack webhook tests...');
+
+  try {
+    // Test 1: Basic Notification
+    await sendSlackMessage({
+      blocks: [
+        {
+          type: 'header',
+          text: {
+            type: 'plain_text',
+            text: 'Basic Notification Test',
+            emoji: true
+          }
+        }
+      ],
+      attachments: [
+        {
+          color: '#0099FF',
+          blocks: [
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: 'This is a simple notification test.'
+              }
+            }
+          ]
+        }
+      ]
+    });
+    console.log('Test 1: Basic notification sent');
+
+    // Test 2: Rich Notification with all features
+    await sendSlackMessage({
+        "text": "Rich Notification Test",
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Rich Notification Test",
+                    "emoji": true
+                }
+            },
+            {
+                "type": "image",
+                "image_url": "https://i.imgur.com/wSTFkRM.png",
+                "alt_text": "Test Image"
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {
+                            "type": "plain_text",
+                            "text": "Open GitHub",
+                            "emoji": true
+                        },
+                        "url": "https://github.com/sammcj/mcp-server-notifier"
+                    }
+                ]
+            }
+        ],
+        "attachments": [
+            {
+                "color": "#2EB67D",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "This notification uses many of the available features.\n<https://github.com/sammcj/mcp-server-notifier|MCP Server Notifier>"
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*Attachments:*\n<https://raw.githubusercontent.com/sammcj/mcp-icons/main/mcp-icon-128.png|Icon>"
+                        }
+                    }
+                ]
+            }
+        ]
+    });
+    console.log('Test 2: Rich notification sent');
+
+    // Test 3: Status Template
+    await sendSlackMessage({
+        "text": "Status Update: Deployment Complete",
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Status Update: Deployment Complete",
+                    "emoji": true
+                }
+            }
+        ],
+        "attachments": [
+            {
+                "color": "#4A154B",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "Deployment of version `1.2.3` to production was successful."
+                        }
+                    },
+                    {
+                        "type": "context",
+                        "elements": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "✅ *Status:* success"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    });
+    console.log('Test 3: Status template sent');
+
+    // Test 4: Progress Template
+    await sendSlackMessage({
+        "text": "Progress: Database Migration",
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Progress: Database Migration",
+                    "emoji": true
+                }
+            }
+        ],
+        "attachments": [
+            {
+                "color": "#2EB67D",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "Migrating user tables..."
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*Progress:*\n[██████    ] 60%"
+                        }
+                    },
+                    {
+                        "type": "context",
+                        "elements": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "*ETA:* 5 minutes"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    });
+    console.log('Test 4: Progress template sent');
+
+    // Test 5: Problem Template
+    await sendSlackMessage({
+        "text": "Problem: API Rate Limit Exceeded",
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Problem: API Rate Limit Exceeded",
+                    "emoji": true
+                }
+            }
+        ],
+        "attachments": [
+            {
+                "color": "#E01E5A",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "The service has exceeded the API rate limit."
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*Error Details:*\n```Too many requests in a short period.```"
+                        }
+                    },
+                    {
+                        "type": "context",
+                        "elements": [
+                            {
+                                "type": "mrkdwn",
+                                "text": "*Severity:* High"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    });
+    console.log('Test 5: Problem template sent');
+
+    // Test 6: Question Template
+    await sendSlackMessage({
+        "text": "Question: Deploy to Production?",
+        "blocks": [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Question: Deploy to Production?",
+                    "emoji": true
+                }
+            }
+        ],
+        "attachments": [
+            {
+                "color": "#E1E44D",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "All tests have passed and QA has approved. Should we deploy the latest changes to production?"
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "*Options:*\n1. Yes\n2. No\n3. Wait until tomorrow"
+                        }
+                    }
+                ]
+            }
+        ]
+    });
+    console.log('Test 6: Question template sent');
+
+
+    console.log('All tests completed successfully!');
+
+  } catch (error) {
+    console.error('Error running tests:', error);
+  }
+}
+
+runTests();

--- a/src/webhooks/slack.ts
+++ b/src/webhooks/slack.ts
@@ -1,43 +1,135 @@
-import { NotificationMessage } from '../config/types.js';
+import { NotificationMessage, MessageAction } from '../config/types.js';
 import { BaseWebhookFormatter } from './base.js';
+import { getTemplate } from '../templates/notification.js';
+import { WebhookConfig } from '../config/types.js';
+
+/**
+ * Slack color constants
+ */
+enum SlackColors {
+  DEFAULT = '#0099FF', // Blue color
+  SUCCESS = '#2EB67D', // Green
+  WARNING = '#E1E44D', // Yellow
+  ERROR = '#E01E5A',   // Red
+  INFO = '#4A154B',    // Purple
+}
+
+/**
+ * Template to color mapping for predefined templates
+ */
+const TEMPLATE_COLORS: Record<string, string> = {
+  status: SlackColors.INFO,
+  progress: SlackColors.SUCCESS,
+  question: SlackColors.WARNING,
+  problem: SlackColors.ERROR,
+};
 
 /**
  * Formatter for Slack webhooks
  */
 export class SlackWebhookFormatter extends BaseWebhookFormatter {
-  formatMessage(message: NotificationMessage): any {
-    const blocks = [];
 
-    // Add title section if provided
+  constructor(config: WebhookConfig) {
+    super(config);
+  }
+
+  formatMessage(message: NotificationMessage): any {
+    let payload: any = {};
+    const blocks: any[] = [];
+    const attachments: any[] = [{
+      blocks: [],
+      color: SlackColors.DEFAULT
+    }];
+
+    // Set the main text of the notification as a fallback for older clients
+    payload.text = message.title || message.body;
+
+    // Handle templates if specified
+    if (message.template && message.templateData) {
+      const template = getTemplate(message.template);
+      if (template) {
+        const templatedTitle = this.applySimpleTemplateVars(template.title, message.templateData);
+        const templatedBody = this.applySimpleTemplateVars(template.message, message.templateData);
+
+        this.buildBaseMessage({ ...message, title: templatedTitle, body: templatedBody }, blocks, attachments, message.templateData);
+        this.applyTemplateFormatting(attachments[0].blocks, message.template, message.templateData);
+      } else {
+        console.warn(`Template not found: ${message.template}, using default formatting`);
+        this.buildBaseMessage(message, blocks, attachments, message.templateData);
+      }
+    } else {
+      this.buildBaseMessage(message, blocks, attachments);
+    }
+
+    // Determine Color: Template > Priority > Default
+    if (message.template && TEMPLATE_COLORS[message.template]) {
+      attachments[0].color = TEMPLATE_COLORS[message.template];
+    } else if (message.priority) {
+      switch (message.priority) {
+        case 5: attachments[0].color = SlackColors.ERROR; break;
+        case 4: attachments[0].color = SlackColors.WARNING; break;
+        case 3: attachments[0].color = SlackColors.INFO; break;
+        case 2: attachments[0].color = SlackColors.DEFAULT; break;
+        case 1: attachments[0].color = SlackColors.SUCCESS; break;
+        default: attachments[0].color = SlackColors.DEFAULT;
+      }
+    }
+
+    // Add actions if provided
+    if (message.actions && message.actions.length > 0) {
+      blocks.push(this.createActionsBlock(message.actions));
+    }
+
+    payload.blocks = blocks;
+    payload.attachments = attachments;
+
+    // Add username and icon from config if they exist
+    if (this.config.username) {
+      payload.username = this.config.username;
+    }
+    if (this.config.avatarUrl) {
+      payload.icon_url = this.config.avatarUrl;
+    }
+
+    return payload;
+  }
+
+  private buildBaseMessage(message: NotificationMessage, blocks: any[], attachments: any[], templateData?: Record<string, any>): void {
+    // Add title
     if (message.title) {
       blocks.push({
         type: 'header',
         text: {
           type: 'plain_text',
-          text: message.title,
+          text: message.title.substring(0, 150), // Max 150 chars for header
           emoji: true
         }
       });
     }
 
-    // Add message body
-    blocks.push({
+    // Add body
+    let bodyText = message.body || '...';
+    if (templateData?.pingRoleId) {
+      // Slack uses `<!subteam^ID>` for user groups or `<!here>`/`<!channel>`
+      bodyText = `<!subteam^${templateData.pingRoleId}> ${bodyText}`;
+    }
+    attachments[0].blocks.push({
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: message.body
+        text: bodyText.substring(0, 3000) // Max 3000 chars for section
       }
     });
 
     // Add link if provided
     if (message.link) {
-      blocks.push({
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `<${message.link}|Open Link>`
-        }
-      });
+        blocks.push({
+            type: 'section',
+            text: {
+                type: 'mrkdwn',
+                text: `<${message.link}|Open Link>`
+            }
+        });
     }
 
     // Add image if provided
@@ -49,8 +141,182 @@ export class SlackWebhookFormatter extends BaseWebhookFormatter {
       });
     }
 
-    return {
-      blocks: blocks
-    };
+    // Add attachments as fields
+    if (message.attachments && message.attachments.length > 0) {
+      const fields = message.attachments.map((url, index) => `*Attachment ${index + 1}:* <${url}>`).join('\n');
+      attachments[0].blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: fields
+        }
+      });
+    }
+  }
+
+  private applyTemplateFormatting(blocks: any[], templateName: string, templateData: Record<string, any>): void {
+    switch (templateName) {
+      case 'status':
+        if (templateData.status) {
+          const statusIcon = this.getStatusIcon(templateData.status);
+          blocks.push({
+            type: 'context',
+            elements: [
+              { type: 'mrkdwn', text: `${statusIcon} *Status:* ${templateData.status}` }
+            ]
+          });
+        }
+        break;
+
+      case 'progress':
+        let percent = -1;
+        if (templateData.percentage !== undefined) {
+          percent = Number(templateData.percentage);
+        } else if (templateData.current !== undefined && templateData.total !== undefined) {
+          percent = Math.round((Number(templateData.current) / Number(templateData.total)) * 100);
+        }
+
+        if (percent >= 0 && percent <= 100) {
+          const progressBar = this.createProgressBar(percent);
+          blocks.push({
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*Progress:*\n${progressBar}`
+            }
+          });
+        }
+        if (templateData.eta) {
+          blocks.push({
+            type: 'context',
+            elements: [
+              { type: 'mrkdwn', text: `*ETA:* ${String(templateData.eta)}` }
+            ]
+          });
+        }
+        break;
+
+      case 'problem':
+        if (templateData.error) {
+          blocks.push({
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*Error Details:*\n\`\`\`${String(templateData.error).substring(0, 2900)}\`\`\``
+            }
+          });
+        }
+        if (templateData.severity) {
+          blocks.push({
+            type: 'context',
+            elements: [
+              { type: 'mrkdwn', text: `*Severity:* ${String(templateData.severity)}` }
+            ]
+          });
+        }
+        break;
+
+      case 'question':
+        if (templateData.options && Array.isArray(templateData.options)) {
+          const optionsText = templateData.options.map((opt: any, i: number) => `${i + 1}. ${String(opt)}`).join('\n');
+          blocks.push({
+            type: 'section',
+            text: {
+              type: 'mrkdwn',
+              text: `*Options:*\n${optionsText}`
+            }
+          });
+        }
+        break;
+    }
+  }
+
+  private createActionsBlock(actions: MessageAction[]): any {
+    const elements = actions.map(action => {
+      if (action.action === 'view') {
+        return {
+          type: 'button',
+          text: {
+            type: 'plain_text',
+            text: action.label.substring(0, 75),
+            emoji: true
+          },
+          url: action.url,
+          action_id: `view_${Math.random().toString(36).substring(7)}`
+        };
+      }
+      // Note: Slack's 'http' actions from webhooks are not supported in the same way as Discord.
+      // We can only create URL buttons. We will treat 'http' as 'view'.
+      return {
+        type: 'button',
+        text: {
+          type: 'plain_text',
+          text: action.label.substring(0, 75),
+          emoji: true
+        },
+        url: action.url,
+        action_id: `http_${Math.random().toString(36).substring(7)}`
+      };
+    }).filter(el => el !== null);
+
+    if (elements.length > 0) {
+      return {
+        type: 'actions',
+        elements: elements.slice(0, 5) // Slack allows max 5 buttons in an action block
+      };
+    }
+    return null;
+  }
+
+  private applySimpleTemplateVars(template: string | undefined, data: Record<string, any>): string {
+    if (!template) return '';
+
+    let result = template;
+
+    const matches = template.match(/{{\.([a-zA-Z0-9_]+)}}/g);
+    if (matches) {
+      matches.forEach(match => {
+        const varName = match.replace("{{.", "").replace("}}", "");
+        if (data[varName] !== undefined) {
+          result = result.replace(match, String(data[varName]));
+        } else {
+          result = result.replace(match, "");
+        }
+      });
+    }
+
+    const ifMatches = result.match(/{{if \.[a-zA-Z0-9_]+}}(.*?){{end}}/gs);
+    if (ifMatches) {
+      ifMatches.forEach(match => {
+        const condVarMatch = match.match(/{{if \.([a-zA-Z0-9_]+)}}/);
+        if (condVarMatch && condVarMatch[1]) {
+          const varName = condVarMatch[1];
+          const content = match.replace(/{{if \.[a-zA-Z0-9_]+}}/, "").replace(/{{end}}/, "");
+
+          if (data[varName]) {
+            result = result.replace(match, content);
+          } else {
+            result = result.replace(match, "");
+          }
+        }
+      });
+    }
+
+    return result.trim();
+  }
+
+  private getStatusIcon(status: string): string {
+    status = status.toLowerCase();
+    if (status.includes('success') || status.includes('complete') || status.includes('ok')) return '✅';
+    if (status.includes('warn') || status.includes('pending')) return '⚠️';
+    if (status.includes('error') || status.includes('fail')) return '❌';
+    if (status.includes('info') || status.includes('running')) return 'ℹ️';
+    return '🔔';
+  }
+
+  private createProgressBar(percentage: number): string {
+    const fullBlocks = Math.floor(percentage / 10);
+    const emptyBlocks = 10 - fullBlocks;
+    return `[${'█'.repeat(fullBlocks)}${' '.repeat(emptyBlocks)}] ${percentage}%`;
   }
 }


### PR DESCRIPTION
This commit introduces comprehensive support for Slack notifications, allowing you to send richly formatted messages to your Slack workspaces.

The key features of this implementation include:
- A new `SlackWebhookFormatter` that uses Slack's Block Kit and attachments to create well-structured and visually appealing notifications.
- Support for templates ('status', 'progress', 'problem', 'question'), which are translated into corresponding Slack message formats.
- Mapping of notification priorities to colored sidebars for easy identification.
- Support for interactive action buttons (as links).
- Updated documentation in `docs/NOTIFICATIONS.md` with detailed instructions on how to configure and use the Slack integration.
- A new example configuration file in `examples/slack-webhook.json`.
- A test script `src/test-slack.js` to facilitate manual testing of the integration.